### PR TITLE
Add inferred priority column with enhanced UI

### DIFF
--- a/src/components/ColumnContextMenu.tsx
+++ b/src/components/ColumnContextMenu.tsx
@@ -8,12 +8,18 @@ interface ColumnContextMenuProps {
 	columnId: string;
 	columnName: string;
 	columnType?: ColumnType;
+	isPriority?: boolean;
+	priorityEnhanced?: boolean;
+	isRelation?: boolean;
+	relationEnhanced?: boolean;
 	currentSort?: 'ASC' | 'DESC' | null;
 	onClose: () => void;
 	onHideColumn: () => void;
 	onSortAsc: () => void;
 	onSortDesc: () => void;
 	onClearSort: () => void;
+	onTogglePriorityEnhanced?: (enabled: boolean) => void;
+	onToggleRelationEnhanced?: (enabled: boolean) => void;
 }
 
 /** Get human-readable type name */
@@ -28,6 +34,7 @@ function getTypeName(type?: ColumnType): string {
 		case 'text': return 'Text';
 		case 'rollup': return 'Rollup';
 		case 'actions': return 'Actions';
+		case 'priority': return 'Priority';
 		default: return 'Text';
 	}
 }
@@ -38,12 +45,18 @@ export function ColumnContextMenu({
 	columnId,
 	columnName,
 	columnType,
+	isPriority,
+	priorityEnhanced,
+	isRelation,
+	relationEnhanced,
 	currentSort,
 	onClose,
 	onHideColumn,
 	onSortAsc,
 	onSortDesc,
 	onClearSort,
+	onTogglePriorityEnhanced,
+	onToggleRelationEnhanced,
 }: ColumnContextMenuProps) {
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -152,6 +165,46 @@ export function ColumnContextMenu({
 				<span className="column-menu-label">Property type</span>
 				<span className="column-menu-value">{getTypeName(columnType)}</span>
 			</div>
+
+			{isRelation && (
+				<>
+					<div className="column-menu-item column-menu-info">
+						<span className="column-menu-icon">⚑</span>
+						<span className="column-menu-label">Inferred Relation Column</span>
+					</div>
+					<div
+						className={`column-menu-item ${relationEnhanced ? 'checked' : ''}`}
+						onClick={() => onToggleRelationEnhanced?.(!relationEnhanced)}
+						title="Wikilink chips with note links, folder-filtered picker, and bidirectional sync"
+					>
+						<span className="column-menu-icon">
+							{relationEnhanced ? '☑' : '☐'}
+						</span>
+						<span className="column-menu-label">Enhanced UI</span>
+						{relationEnhanced && <span className="column-menu-check">✓</span>}
+					</div>
+				</>
+			)}
+
+			{isPriority && (
+				<>
+					<div className="column-menu-item column-menu-info">
+						<span className="column-menu-icon">⚑</span>
+						<span className="column-menu-label">Inferred Priority Column</span>
+					</div>
+					<div
+						className={`column-menu-item ${priorityEnhanced ? 'checked' : ''}`}
+						onClick={() => onTogglePriorityEnhanced?.(!priorityEnhanced)}
+						title="Color-coded chips: red for high, yellow for medium, blue for low"
+					>
+						<span className="column-menu-icon">
+							{priorityEnhanced ? '☑' : '☐'}
+						</span>
+						<span className="column-menu-label">Enhanced UI</span>
+						{priorityEnhanced && <span className="column-menu-check">✓</span>}
+					</div>
+				</>
+			)}
 		</div>,
 		document.body
 	);

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface WikiLink {
 }
 
 /** Column data type for icon display */
-export type ColumnType = 'file' | 'relation' | 'tags' | 'list' | 'checkbox' | 'number' | 'text' | 'date' | 'datetime' | 'rollup' | 'actions';
+export type ColumnType = 'file' | 'relation' | 'tags' | 'list' | 'checkbox' | 'number' | 'text' | 'date' | 'datetime' | 'rollup' | 'actions' | 'priority';
 
 /** Column metadata for the table */
 export interface ColumnMeta {
@@ -33,12 +33,18 @@ export interface ColumnMeta {
 	displayName: string;
 	/** Whether this column contains relation (wikilink list) values */
 	isRelation: boolean;
+	/** Whether enhanced relation UI is active (wikilink chips + picker) */
+	relationEnhanced?: boolean;
 	/** Whether this is a computed rollup column */
 	isRollup?: boolean;
 	/** Rollup configuration (present when isRollup is true) */
 	rollupConfig?: RollupConfig;
 	/** Folder path to filter relation picker options (auto-inferred from property name) */
 	relationFolderFilter?: string;
+	/** Whether this is an inferred priority column */
+	isPriority?: boolean;
+	/** Whether enhanced priority UI is active (colored chips) */
+	priorityEnhanced?: boolean;
 	/** Whether this is a quick actions column */
 	isQuickActions?: boolean;
 	/** Column data type for header icon */

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,22 @@
 	color: var(--tag-color, hsl(258, 60%, 65%));
 }
 
+/* Priority chip styling */
+.cell-chip-priority {
+	font-weight: var(--font-semibold);
+}
+
+.cell-chip-priority .cell-chip-remove {
+	color: inherit;
+	opacity: 0.6;
+}
+
+.cell-chip-priority .cell-chip-remove:hover {
+	opacity: 1;
+	background-color: rgba(0, 0, 0, 0.15);
+	color: inherit;
+}
+
 /* Empty placeholder for list cells */
 .cell-empty-placeholder {
 	color: var(--text-faint);


### PR DESCRIPTION
## Summary
- Adds inferred priority column detection (property name = `priority`) with color-coded chips: red (high), yellow (medium), blue (low)
- Adds "Enhanced UI" toggle in column right-click context menu for both priority and relation columns, persisted per-view in `.base` file
- Flag icon for priority column header when enhanced UI is on, reverts to default type icon when off
- Wikilink values display as clean basenames when relation enhanced UI is toggled off

## Test plan
- [x] Verify priority column shows colored chips for high/medium/low values
- [x] Right-click priority column → "Inferred Priority Column" label + "Enhanced UI" toggle visible
- [x] Toggle off enhanced UI → chips revert to plain style, header icon reverts to List
- [x] Right-click relation column → "Inferred Relation Column" label + toggle works
- [x] Hover "Enhanced UI" shows tooltip description


# Snip

<img width="730" height="280" alt="image" src="https://github.com/user-attachments/assets/7934be9c-3a24-4215-8d53-1727f57eef43" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)