### PR TITLE
Render URL text cells as clickable links

### DIFF
--- a/src/components/RelationalTable.tsx
+++ b/src/components/RelationalTable.tsx
@@ -8,7 +8,7 @@ import {
 	Hash,
 	Sigma,
 	Zap,
-	Type,
+	AlignJustify,
 	Flag,
 	Calendar,
 	ChevronRight,
@@ -113,7 +113,7 @@ function getColumnTypeIcon(type?: ColumnType): ReactNode {
 		case 'priority': return <Flag {...props} />;
 		case 'date': return <Calendar {...props} />;
 		case 'datetime': return <Calendar {...props} />;
-		case 'text': return <Type {...props} />;
+		case 'text': return <AlignJustify {...props} />;
 		default: return null;
 	}
 }

--- a/src/components/cells/EditableCell.tsx
+++ b/src/components/cells/EditableCell.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Calendar } from 'lucide-react';
+import { Calendar, ExternalLink, Pencil } from 'lucide-react';
 import type { CellContext } from '@tanstack/react-table';
 import type { TableRowData } from '../../types';
 import { TextEditor } from '../editors/TextEditor';
@@ -289,6 +289,35 @@ export function EditableCell({
 		);
 	}
 
+	// URL text — clickable link + pencil icon on hover to edit
+	const strValue = String(value);
+	if (typeof value === 'string' && /^https?:\/\/.+/.test(strValue)) {
+		return (
+			<span
+				className="cell-text cell-url"
+				tabIndex={0}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter') setEditing(true);
+				}}
+			>
+				<a
+					href={strValue}
+					className="cell-url-link"
+					title={strValue}
+					draggable={false}
+					onClick={(e) => {
+						e.preventDefault();
+						window.open(strValue, '_blank');
+					}}
+				>
+					{strValue}
+				</a>
+				<ExternalLink size={14} className="cell-url-icon cell-url-icon-link" onClick={(e) => { e.stopPropagation(); window.open(strValue, '_blank'); }} />
+				<Pencil size={14} className="cell-url-icon cell-url-icon-edit" onClick={(e) => { e.stopPropagation(); setEditing(true); }} />
+			</span>
+		);
+	}
+
 	// Text/number — double-click to edit
 	return (
 		<span
@@ -299,7 +328,7 @@ export function EditableCell({
 			}}
 			tabIndex={0}
 		>
-			{String(value)}
+			{strValue}
 		</span>
 	);
 }

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@
 .relational-table {
 	width: 100%;
 	border-collapse: collapse;
-	table-layout: auto;
+	table-layout: fixed;
 }
 
 /* Header */
@@ -40,6 +40,7 @@
 	border-bottom: 1px solid var(--background-modifier-border);
 	border-right: 1px solid var(--background-modifier-border);
 	vertical-align: middle;
+	overflow: hidden;
 }
 
 .relational-table td:last-child {
@@ -95,6 +96,45 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	max-width: 300px;
+	display: inline-block;
+}
+
+/* URL cells */
+.cell-url {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 100%;
+}
+.cell-url-link {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+	flex: 1 1 auto;
+	color: var(--link-color, var(--text-accent));
+	text-decoration: none;
+	cursor: pointer;
+	-webkit-user-drag: none;
+}
+.cell-url-link:hover {
+	text-decoration: underline;
+}
+.cell-url-icon {
+	flex-shrink: 0;
+	color: var(--text-muted);
+	cursor: pointer;
+}
+.cell-url-icon-link {
+	display: inline-block;
+}
+.cell-url-icon-edit {
+	display: none;
+}
+.cell-url:hover .cell-url-icon-link {
+	display: none;
+}
+.cell-url:hover .cell-url-icon-edit {
 	display: inline-block;
 }
 


### PR DESCRIPTION
## Summary
- Text cells containing URLs now render as clickable links with truncated display and external link icon, matching vanilla Bases behavior
- Hover swaps external icon to pencil icon for inline editing
- Text column header icon changed from T to ≡ to match vanilla Bases
- Fixed column resizing: switched `table-layout` from `auto` to `fixed` so columns respect explicit widths and URL content doesn't prevent shrinking
- Prevented native link drag from hijacking column resize handles (`draggable=false`, `-webkit-user-drag: none`)


<img width="1030" height="490" alt="image" src="https://github.com/user-attachments/assets/1d07858b-7fc5-47a6-acba-1e1b9a2e8258" />

<img width="1013" height="515" alt="image" src="https://github.com/user-attachments/assets/5f2bbb95-d8e4-4f73-8b70-b1ed61daed6b" />


## Test plan
- [x] Verify URL text cells render as clickable links that open in browser
- [x] Verify hover shows pencil icon and clicking it enters edit mode
- [ ] Verify column resizing works correctly with URL columns
- [x] Verify non-URL text cells still render and edit normally
- [x] Verify text column headers show ≡ icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)