### PR TITLE
Fix getBaseFolder returning undefined at vault root

### DIFF
--- a/src/relational-table-view.ts
+++ b/src/relational-table-view.ts
@@ -629,16 +629,17 @@ export class RelationalTableView extends BasesView {
 	 * Used for both folder filtering and as a relation detection signal.
 	 */
 	private matchRelationSubfolder(propId: string, baseFolder?: string): string | undefined {
-		if (!baseFolder) return undefined;
+		if (baseFolder == null) return undefined;
 
 		const propName = this.extractPropertyName(propId).toLowerCase();
+		const prefix = baseFolder ? `${baseFolder}/` : '';
 		const candidates = [
-			`${baseFolder}/${propName}`,
-			`${baseFolder}/${propName}s`,
+			`${prefix}${propName}`,
+			`${prefix}${propName}s`,
 		];
 		// Also try without trailing 's' if propName already ends with 's'
 		if (propName.endsWith('s') && propName.length > 1) {
-			candidates.push(`${baseFolder}/${propName.slice(0, -1)}`);
+			candidates.push(`${prefix}${propName.slice(0, -1)}`);
 		}
 
 		for (const candidate of candidates) {
@@ -670,13 +671,13 @@ export class RelationalTableView extends BasesView {
 			while (!folders[i].startsWith(common)) {
 				const lastSlash = common.lastIndexOf('/');
 				common = lastSlash >= 0 ? common.substring(0, lastSlash) : '';
-				if (!common) return undefined;
+				if (!common) return '';  // vault root
 			}
 		}
 
 		// Go one level up to include sibling folders
 		const parentSlash = common.lastIndexOf('/');
-		return parentSlash >= 0 ? common.substring(0, parentSlash) : common || undefined;
+		return parentSlash >= 0 ? common.substring(0, parentSlash) : '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `getBaseFolder()` now returns `""` (vault root) instead of `undefined` when entries are one level below root
- `matchRelationSubfolder()` updated to handle empty-string baseFolder — builds paths like `projects` instead of `/projects`
- Enables relation detection for properties like `project` → `Projects/` when the base file filters entries under `tasks/`

Fixes #4

## Test plan
- [ ] Open a vault where tasks are in `tasks/YYYY-MM-DD/` and projects are in `Projects/` at root
- [ ] Confirm `note.project` is auto-detected as a relation column
- [ ] Confirm the relation picker shows files from `Projects/`
- [ ] Verify existing vaults with deeper nesting (e.g. `test-v1/tasks/`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)