### PR TITLE
Clean up config panel UI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,8 @@ import { RelationalTableView } from './relational-table-view';
 export default class PowerbasePlugin extends Plugin {
 	async onload() {
 		this.registerBasesView('relational-table', {
-			name: 'Relational Table',
-			icon: 'table-2',
+			name: 'Powerbase',
+			icon: 'database',
 			factory: (controller: any, containerEl: HTMLElement) =>
 				new RelationalTableView(controller, containerEl, this),
 			options: () => RelationalTableView.getViewOptions(),


### PR DESCRIPTION
## Summary

- Rename layout from "Relational Table" to "Powerbase" with `database` Lucide icon
- Remove dead "Relation Detection" dropdown (config was never read; folder matching always runs)
- Remove "Quick Actions" config input (feature was removed)
- Add collapsible "Relations (N)" group showing detected relations as read-only info
- Move rollup/bidi count settings into collapsible "Advanced" group

Closes #9

## Test plan

- [ ] Reload plugin in Obsidian
- [ ] Open a `.base` file → Configure view → verify layout says "Powerbase" with database icon
- [ ] Verify "Relations (N)" group is collapsible and shows detected columns + folders
- [ ] Verify "Relation Detection" dropdown is gone
- [ ] Verify "Quick Actions" input is gone
- [ ] Verify rollup/bidi settings are under collapsible "Advanced" group
- [ ] Verify rollups and bidi sync still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)