### PR TITLE
Rollup columns UI/UX polish

### DIFF
--- a/src/components/ColumnContextMenu.tsx
+++ b/src/components/ColumnContextMenu.tsx
@@ -101,6 +101,8 @@ export function ColumnContextMenu({
 		}
 	}, [x, y]);
 
+	const isRollup = columnType === 'rollup';
+
 	// Use portal to render to document.body for correct fixed positioning
 	return createPortal(
 		<div
@@ -108,63 +110,74 @@ export function ColumnContextMenu({
 			className="column-context-menu"
 			style={{ left: x, top: y }}
 		>
-			<div
-				className="column-menu-item"
-				onClick={() => {
-					onHideColumn();
-					onClose();
-				}}
-			>
-				<span className="column-menu-icon">👁</span>
-				<span className="column-menu-label">Hide column</span>
-			</div>
+			{!isRollup && (
+				<>
+					<div
+						className="column-menu-item"
+						onClick={() => {
+							onHideColumn();
+							onClose();
+						}}
+					>
+						<span className="column-menu-icon">👁</span>
+						<span className="column-menu-label">Hide column</span>
+					</div>
 
-			<div className="column-menu-separator" />
+					<div className="column-menu-separator" />
 
-			<div
-				className={`column-menu-item ${currentSort === 'ASC' ? 'checked' : ''}`}
-				onClick={() => {
-					onSortAsc();
-					onClose();
-				}}
-			>
-				<span className="column-menu-icon">↑</span>
-				<span className="column-menu-label">Sort A → Z</span>
-				{currentSort === 'ASC' && <span className="column-menu-check">✓</span>}
-			</div>
+					<div
+						className={`column-menu-item ${currentSort === 'ASC' ? 'checked' : ''}`}
+						onClick={() => {
+							onSortAsc();
+							onClose();
+						}}
+					>
+						<span className="column-menu-icon">↑</span>
+						<span className="column-menu-label">Sort A → Z</span>
+						{currentSort === 'ASC' && <span className="column-menu-check">✓</span>}
+					</div>
 
-			<div
-				className={`column-menu-item ${currentSort === 'DESC' ? 'checked' : ''}`}
-				onClick={() => {
-					onSortDesc();
-					onClose();
-				}}
-			>
-				<span className="column-menu-icon">↓</span>
-				<span className="column-menu-label">Sort Z → A</span>
-				{currentSort === 'DESC' && <span className="column-menu-check">✓</span>}
-			</div>
+					<div
+						className={`column-menu-item ${currentSort === 'DESC' ? 'checked' : ''}`}
+						onClick={() => {
+							onSortDesc();
+							onClose();
+						}}
+					>
+						<span className="column-menu-icon">↓</span>
+						<span className="column-menu-label">Sort Z → A</span>
+						{currentSort === 'DESC' && <span className="column-menu-check">✓</span>}
+					</div>
 
-			{currentSort && (
-				<div
-					className="column-menu-item danger"
-					onClick={() => {
-						onClearSort();
-						onClose();
-					}}
-				>
-					<span className="column-menu-icon">✕</span>
-					<span className="column-menu-label">Clear sort</span>
-				</div>
+					{currentSort && (
+						<div
+							className="column-menu-item danger"
+							onClick={() => {
+								onClearSort();
+								onClose();
+							}}
+						>
+							<span className="column-menu-icon">✕</span>
+							<span className="column-menu-label">Clear sort</span>
+						</div>
+					)}
+
+					<div className="column-menu-separator" />
+				</>
 			)}
-
-			<div className="column-menu-separator" />
 
 			<div className="column-menu-item column-menu-info">
 				<span className="column-menu-icon">ⓘ</span>
 				<span className="column-menu-label">Property type</span>
 				<span className="column-menu-value">{getTypeName(columnType)}</span>
 			</div>
+
+			{isRollup && (
+				<div className="column-menu-item column-menu-info">
+					<span className="column-menu-icon">⚑</span>
+					<span className="column-menu-label">Powerbase Column</span>
+				</div>
+			)}
 
 			{isRelation && (
 				<>

--- a/src/components/RelationalTable.tsx
+++ b/src/components/RelationalTable.tsx
@@ -429,7 +429,7 @@ export function RelationalTable({
 										key={header.id}
 										style={{ width: header.getSize() }}
 										onContextMenu={(e) => {
-											if (col && !col.isQuickActions && !col.isRollup) {
+											if (col && !col.isQuickActions) {
 												handleColumnContextMenu(e, header.id, col.displayName, col.columnType, col.isPriority, col.priorityEnhanced, col.isRelation, col.relationEnhanced);
 											}
 										}}

--- a/src/components/cells/RollupCell.tsx
+++ b/src/components/cells/RollupCell.tsx
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { CellContext } from '@tanstack/react-table';
 import type { TableRowData } from '../../types';
+import { useApp } from '../AppContext';
 
 /**
  * Read-only cell renderer for rollup (aggregated) values.
- * Displays numbers, percentages, and comma-separated lists.
+ * Displays numbers, percentages, and link chips for list/unique rollups.
  */
-export function RollupCell({ getValue }: CellContext<TableRowData, unknown>) {
+export function RollupCell({ getValue, row }: CellContext<TableRowData, unknown>) {
 	const value = getValue();
+	const app = useApp();
+	const sourcePath = row.original.file.path;
+
+	const handleLinkClick = useCallback(
+		(e: React.MouseEvent, path: string) => {
+			e.stopPropagation();
+			app.workspace.openLinkText(path, sourcePath);
+		},
+		[app, sourcePath]
+	);
 
 	if (value === null || value === undefined) {
 		return <span className="cell-empty" />;
@@ -27,7 +38,38 @@ export function RollupCell({ getValue }: CellContext<TableRowData, unknown>) {
 		return <span className="rollup-cell rollup-percent">{value}</span>;
 	}
 
-	// List/unique strings
+	// Array of link objects / strings from list/unique aggregation
+	if (Array.isArray(value)) {
+		return (
+			<div className="rollup-cell rollup-links">
+				{value.map((item, i) => {
+					if (typeof item === 'object' && item.path) {
+						return (
+							<span
+								key={i}
+								className="relation-chip"
+								title={item.path}
+							>
+								<span
+									className="relation-chip-label"
+									onClick={(e) => handleLinkClick(e, item.path)}
+								>
+									{item.display}
+								</span>
+							</span>
+						);
+					}
+					return (
+						<span key={i} className="rollup-text-item">
+							{String(item)}
+						</span>
+					);
+				})}
+			</div>
+		);
+	}
+
+	// Fallback: plain string
 	return (
 		<span className="rollup-cell rollup-list" title={String(value)}>
 			{String(value)}

--- a/styles.css
+++ b/styles.css
@@ -474,6 +474,11 @@
 	color: var(--text-muted);
 }
 
+/* Rollup chips: symmetric padding (no remove button) */
+.rollup-links .relation-chip {
+	padding: 0 8px;
+}
+
 .rollup-list {
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
## Summary
- Rollup `list`/`unique` aggregations now resolve wikilinks and render as clickable chips (same style as relation columns)
- Clicking a rollup chip opens the linked note
- Symmetric chip padding for rollup chips (no remove button)
- Rollup column headers now have a context menu showing property type "Rollup" and a "Powerbase Column" flag (no hide/sort actions)

Closes #18

<img width="1375" height="447" alt="image" src="https://github.com/user-attachments/assets/d1b23cab-264d-4c37-9059-c93706b606f2" />

## Test plan
- [x] Organization rollup column shows clickable chips instead of raw `[[...]]` text
- [x] Clicking a chip opens the linked note
- [x] Chip padding is symmetric (no extra space on right)
- [x] Right-click rollup header shows type info + Powerbase Column flag, no hide/sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)