### PR TITLE
Persist column widths and fix file name truncation

### DIFF
--- a/src/components/RelationalTable.tsx
+++ b/src/components/RelationalTable.tsx
@@ -81,6 +81,8 @@ interface RelationalTableProps {
 	onTogglePriorityEnhanced?: (columnId: string, enabled: boolean) => void;
 	onToggleStatusEnhanced?: (columnId: string, enabled: boolean) => void;
 	onToggleRelationEnhanced?: (columnId: string, enabled: boolean) => void;
+	columnSizing?: Record<string, number>;
+	onColumnResize?: (columnId: string, width: number) => void;
 }
 
 interface ContextMenuState {
@@ -139,11 +141,15 @@ export function RelationalTable({
 	onTogglePriorityEnhanced,
 	onToggleStatusEnhanced,
 	onToggleRelationEnhanced,
+	columnSizing: persistedColumnSizing,
+	onColumnResize,
 }: RelationalTableProps) {
 	const [focusedCell, setFocusedCell] = useState<FocusedCell | null>(null);
 	const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+	const [columnSizing, setColumnSizing] = useState<Record<string, number>>(persistedColumnSizing ?? {});
 	const tableContainerRef = useRef<HTMLDivElement>(null);
+	const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// Clear focus when clicking anywhere outside the table
 	useEffect(() => {
@@ -207,7 +213,7 @@ export function RelationalTable({
 									: col.propertyId === 'file.name'
 										? FileNameCell
 										: EditableCell,
-						size: 150,
+						size: col.propertyId === 'file.name' ? 250 : 150,
 						minSize: 50,
 					}
 				)
@@ -221,6 +227,20 @@ export function RelationalTable({
 		getCoreRowModel: getCoreRowModel(),
 		manualSorting: true,
 		columnResizeMode: 'onChange',
+		state: { columnSizing },
+		onColumnSizingChange: (updater) => {
+			const next = typeof updater === 'function' ? updater(columnSizing) : updater;
+			setColumnSizing(next);
+			// Debounce persist to config
+			if (onColumnResize) {
+				if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+				resizeTimerRef.current = setTimeout(() => {
+					for (const [id, width] of Object.entries(next)) {
+						onColumnResize(id, width);
+					}
+				}, 300);
+			}
+		},
 		meta: {
 			updateRelation: (
 				rowIndex: number,

--- a/src/relational-table-view.ts
+++ b/src/relational-table-view.ts
@@ -331,6 +331,8 @@ export class RelationalTableView extends BasesView {
 					onTogglePriorityEnhanced: this.handleTogglePriorityEnhanced.bind(this),
 					onToggleStatusEnhanced: this.handleToggleStatusEnhanced.bind(this),
 					onToggleRelationEnhanced: this.handleToggleRelationEnhanced.bind(this),
+				columnSizing: this.getPersistedColumnSizing(columns),
+				onColumnResize: this.handleColumnResize.bind(this),
 				}))
 			)
 		);
@@ -505,6 +507,28 @@ export class RelationalTableView extends BasesView {
 	private handleToggleRelationEnhanced(columnId: string, enabled: boolean): void {
 		(this.config as any).set?.(`relationEnhanced_${columnId}`, enabled ? 'true' : 'false');
 		this.renderTable();
+	}
+
+	/**
+	 * Persist a column width to config (called on resize end).
+	 */
+	private handleColumnResize(columnId: string, width: number): void {
+		(this.config as any).set?.(`colWidth_${columnId}`, String(Math.round(width)));
+	}
+
+	/**
+	 * Load persisted column widths from config.
+	 */
+	private getPersistedColumnSizing(columns: { propertyId: string }[]): Record<string, number> {
+		const sizing: Record<string, number> = {};
+		for (const col of columns) {
+			const raw = this.config.get(`colWidth_${col.propertyId}`) as string | undefined;
+			if (raw) {
+				const w = parseInt(raw, 10);
+				if (w > 0) sizing[col.propertyId] = w;
+			}
+		}
+		return sizing;
 	}
 
 	/**

--- a/styles.css
+++ b/styles.css
@@ -580,7 +580,7 @@ td.cell-focused {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	max-width: 300px;
+	width: 100%;
 	display: inline-block;
 }
 


### PR DESCRIPTION
## Summary
- Column widths persist to `.base` config (`colWidth_{propertyId}`) — resizing sticks across reloads
- Replaced hard-coded `max-width: 300px` on file name cells with `width: 100%` for dynamic truncation
- Default `file.name` column bumped to 250px

Closes #27

## Test plan
- [ ] Resize file name column in a base, reload vault — width should persist
- [ ] Resize other columns — verify they also persist
- [ ] Verify long file names truncate with ellipsis at the column boundary (not at 300px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)