### PR TITLE
Add 'in progress' status option

### DIFF
--- a/src/components/cells/EditableCell.tsx
+++ b/src/components/cells/EditableCell.tsx
@@ -18,9 +18,11 @@ const PRIORITY_DEFAULT = { bg: '#e0e0e0', text: '#1a1a1a' };
 
 /** Status value → chip color mapping */
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-	todo:    { bg: '#f5d89a', text: '#1a1a1a' },
-	backlog: { bg: '#d5d5d5', text: '#1a1a1a' },
-	done:    { bg: '#4caf50', text: '#ffffff' },
+	'todo':        { bg: '#f5d89a', text: '#1a1a1a' },
+	'in progress': { bg: '#58a6ff', text: '#ffffff' },
+	'backlog':     { bg: '#d5d5d5', text: '#1a1a1a' },
+	'blocked':     { bg: '#888888', text: '#ffffff' },
+	'done':        { bg: '#4caf50', text: '#ffffff' },
 };
 const STATUS_DEFAULT = { bg: '#e0e0e0', text: '#1a1a1a' };
 

--- a/src/components/editors/StatusEditor.tsx
+++ b/src/components/editors/StatusEditor.tsx
@@ -2,14 +2,15 @@ import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 /** Default status options */
-const STATUS_OPTIONS = ['todo', 'backlog', 'blocked', 'done'] as const;
+const STATUS_OPTIONS = ['todo', 'in progress', 'backlog', 'blocked', 'done'] as const;
 
 /** Status value color mapping */
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-	todo:    { bg: '#f5d89a', text: '#1a1a1a' },
-	backlog: { bg: '#e0e0e0', text: '#1a1a1a' },
-	blocked: { bg: '#888888', text: '#ffffff' },
-	done:    { bg: '#4caf50', text: '#ffffff' },
+	'todo':        { bg: '#f5d89a', text: '#1a1a1a' },
+	'in progress': { bg: '#58a6ff', text: '#ffffff' },
+	'backlog':     { bg: '#d5d5d5', text: '#1a1a1a' },
+	'blocked':     { bg: '#888888', text: '#ffffff' },
+	'done':        { bg: '#4caf50', text: '#ffffff' },
 };
 
 interface StatusEditorProps {


### PR DESCRIPTION
## Summary
- Add 'in progress' (blue `#58a6ff`) to enhanced status dropdown and chip display
- Add missing 'blocked' color to EditableCell display map (was falling back to default gray)
- Align backlog color between StatusEditor and EditableCell (`#d5d5d5`)

Closes #29

## Test plan
- [ ] Open a base with a status column (enhanced mode on)
- [ ] Click a status cell — verify 'in progress' appears in dropdown between 'todo' and 'backlog'
- [ ] Select 'in progress' — verify blue pill renders in cell
- [ ] Verify 'blocked' now shows dark gray pill (not default light gray)

🤖 Generated with [Claude Code](https://claude.com/claude-code)