### PR TITLE
Fix cell edits targeting wrong row when table is grouped

### DIFF
--- a/src/components/RelationalTable.tsx
+++ b/src/components/RelationalTable.tsx
@@ -35,12 +35,12 @@ import { ColumnContextMenu } from './ColumnContextMenu';
 declare module '@tanstack/react-table' {
 	interface TableMeta<TData extends RowData> {
 		updateRelation: (
-			rowIndex: number,
+			file: import('obsidian').TFile,
 			columnId: string,
 			newLinks: string[]
 		) => void;
 		updateCell?: (
-			rowIndex: number,
+			file: import('obsidian').TFile,
 			columnId: string,
 			value: any
 		) => void;
@@ -53,7 +53,7 @@ declare module '@tanstack/react-table' {
 		isColumnPriorityEnhanced: (columnId: string) => boolean;
 		isColumnStatusEnhanced: (columnId: string) => boolean;
 		quickActions?: QuickActionConfig[];
-		executeQuickAction?: (rowIndex: number, action: QuickActionConfig) => Promise<void>;
+		executeQuickAction?: (file: import('obsidian').TFile, action: QuickActionConfig) => Promise<void>;
 	}
 }
 
@@ -281,21 +281,15 @@ export function RelationalTable({
 		},
 		meta: {
 			updateRelation: (
-				rowIndex: number,
+				file: TFile,
 				columnId: string,
 				newLinks: string[]
 			) => {
-				const file = rows[rowIndex]?.file;
-				if (file) {
-					onUpdateRelation(file, columnId, newLinks);
-				}
+				onUpdateRelation(file, columnId, newLinks);
 			},
 			updateCell: onUpdateCell
-				? (rowIndex: number, columnId: string, value: any) => {
-						const file = rows[rowIndex]?.file;
-						if (file) {
-							onUpdateCell(file, columnId, value);
-						}
+				? (file: TFile, columnId: string, value: any) => {
+						onUpdateCell(file, columnId, value);
 				  }
 				: undefined,
 			focusedCell,
@@ -336,11 +330,8 @@ export function RelationalTable({
 			},
 			quickActions,
 			executeQuickAction: onExecuteQuickAction
-				? async (rowIndex: number, action: QuickActionConfig) => {
-						const file = rows[rowIndex]?.file;
-						if (file) {
-							await onExecuteQuickAction(file, action);
-						}
+				? async (file: TFile, action: QuickActionConfig) => {
+						await onExecuteQuickAction(file, action);
 				  }
 				: undefined,
 		},

--- a/src/components/cells/EditableCell.tsx
+++ b/src/components/cells/EditableCell.tsx
@@ -58,9 +58,9 @@ export function EditableCell({
 	const handleSave = useCallback(
 		(newValue: any) => {
 			setEditing(false);
-			table.options.meta?.updateCell?.(row.index, column.id, newValue);
+			table.options.meta?.updateCell?.(row.original.file, column.id, newValue);
 		},
-		[table, row.index, column.id]
+		[table, row.original.file, column.id]
 	);
 
 	const handleCancel = useCallback(() => {
@@ -144,7 +144,7 @@ export function EditableCell({
 						currentValue={null}
 						onSelect={(selected) => {
 							setEditing(false);
-							table.options.meta?.updateCell?.(row.index, column.id, selected);
+							table.options.meta?.updateCell?.(row.original.file, column.id, selected);
 						}}
 						onClose={() => setEditing(false)}
 					/>
@@ -166,7 +166,7 @@ export function EditableCell({
 						currentValue={null}
 						onSelect={(selected) => {
 							setEditing(false);
-							table.options.meta?.updateCell?.(row.index, column.id, selected);
+							table.options.meta?.updateCell?.(row.original.file, column.id, selected);
 						}}
 						onClose={() => setEditing(false)}
 					/>
@@ -191,7 +191,7 @@ export function EditableCell({
 						suggestions={allValues}
 						isTagColumn={isTagColumn}
 						onAdd={(newValue) => {
-							table.options.meta?.updateCell?.(row.index, column.id, [newValue]);
+							table.options.meta?.updateCell?.(row.original.file, column.id, [newValue]);
 						}}
 						onRemove={() => {}}
 						onClose={() => setEditing(false)}
@@ -228,7 +228,7 @@ export function EditableCell({
 				className="cell-checkbox cell-checkbox-editable"
 				onChange={(e) => {
 					table.options.meta?.updateCell?.(
-						row.index,
+						row.original.file,
 						column.id,
 						e.target.checked
 					);
@@ -250,7 +250,7 @@ export function EditableCell({
 					currentValue={priorityValue}
 					onSelect={(selected) => {
 						setEditing(false);
-						table.options.meta?.updateCell?.(row.index, column.id, selected);
+						table.options.meta?.updateCell?.(row.original.file, column.id, selected);
 					}}
 					onClose={() => setEditing(false)}
 				/>
@@ -272,7 +272,7 @@ export function EditableCell({
 								className="cell-chip-remove"
 								onClick={(e) => {
 									e.stopPropagation();
-									table.options.meta?.updateCell?.(row.index, column.id, null);
+									table.options.meta?.updateCell?.(row.original.file, column.id, null);
 								}}
 								title="Remove"
 							>
@@ -290,7 +290,7 @@ export function EditableCell({
 							className="cell-chip-remove"
 							onClick={(e) => {
 								e.stopPropagation();
-								table.options.meta?.updateCell?.(row.index, column.id, null);
+								table.options.meta?.updateCell?.(row.original.file, column.id, null);
 							}}
 							title="Remove"
 						>
@@ -320,7 +320,7 @@ export function EditableCell({
 					currentValue={statusValue}
 					onSelect={(selected) => {
 						setEditing(false);
-						table.options.meta?.updateCell?.(row.index, column.id, selected);
+						table.options.meta?.updateCell?.(row.original.file, column.id, selected);
 					}}
 					onClose={() => setEditing(false)}
 				/>
@@ -341,7 +341,7 @@ export function EditableCell({
 								className="cell-chip-remove"
 								onClick={(e) => {
 									e.stopPropagation();
-									table.options.meta?.updateCell?.(row.index, column.id, null);
+									table.options.meta?.updateCell?.(row.original.file, column.id, null);
 								}}
 								title="Remove"
 							>
@@ -359,7 +359,7 @@ export function EditableCell({
 							className="cell-chip-remove"
 							onClick={(e) => {
 								e.stopPropagation();
-								table.options.meta?.updateCell?.(row.index, column.id, null);
+								table.options.meta?.updateCell?.(row.original.file, column.id, null);
 							}}
 							title="Remove"
 						>
@@ -390,12 +390,12 @@ export function EditableCell({
 
 		const handleRemove = (index: number) => {
 			const newValue = currentValues.filter((_, i) => i !== index);
-			table.options.meta?.updateCell?.(row.index, column.id, newValue);
+			table.options.meta?.updateCell?.(row.original.file, column.id, newValue);
 		};
 
 		const handleAdd = (newValue: string) => {
 			const updated = [...currentValues, newValue];
-			table.options.meta?.updateCell?.(row.index, column.id, updated);
+			table.options.meta?.updateCell?.(row.original.file, column.id, updated);
 		};
 
 		// Editing mode - show ChipEditor with inline cursor

--- a/src/components/cells/QuickActionsCell.tsx
+++ b/src/components/cells/QuickActionsCell.tsx
@@ -17,7 +17,7 @@ export function QuickActionsCell({
 		| QuickActionConfig[]
 		| undefined;
 	const executeQuickAction = table.options.meta?.executeQuickAction as
-		| ((rowIndex: number, action: QuickActionConfig) => Promise<void>)
+		| ((file: import('obsidian').TFile, action: QuickActionConfig) => Promise<void>)
 		| undefined;
 
 	const handleClick = useCallback(
@@ -26,7 +26,7 @@ export function QuickActionsCell({
 
 			setExecutingId(action.id);
 			try {
-				await executeQuickAction(row.index, action);
+				await executeQuickAction(row.original.file, action);
 				// Show success state briefly
 				setSuccessId(action.id);
 				setTimeout(() => setSuccessId(null), 800);
@@ -36,7 +36,7 @@ export function QuickActionsCell({
 				setExecutingId(null);
 			}
 		},
-		[executeQuickAction, executingId, row.index]
+		[executeQuickAction, executingId, row.original.file]
 	);
 
 	if (!quickActions || quickActions.length === 0) {

--- a/src/components/cells/RelationCell.tsx
+++ b/src/components/cells/RelationCell.tsx
@@ -64,18 +64,18 @@ export function RelationCell({
 			const remaining = links
 				.filter((_, i) => i !== index)
 				.map((l) => l.raw);
-			table.options.meta?.updateRelation(row.index, column.id, remaining);
+			table.options.meta?.updateRelation(row.original.file, column.id, remaining);
 		},
-		[links, table, row.index, column.id]
+		[links, table, row.original.file, column.id]
 	);
 
 	const handleAdd = useCallback(
 		(notePath: string) => {
 			const wikilink = ParseService.formatAsWikiLink(notePath);
 			const newLinks = [...links.map(l => l.raw), wikilink];
-			table.options.meta?.updateRelation(row.index, column.id, newLinks);
+			table.options.meta?.updateRelation(row.original.file, column.id, newLinks);
 		},
-		[links, table, row.index, column.id]
+		[links, table, row.original.file, column.id]
 	);
 
 	// Edit mode - inline ChipEditor


### PR DESCRIPTION
## Summary
- Fix `row.index` lookup bug that caused cell edits to target the wrong file when grouping is active
- Pass `row.original.file` directly instead of `rows[rowIndex]` across all edit handlers (updateCell, updateRelation, executeQuickAction)
- Updated TableMeta type declarations to accept TFile instead of rowIndex

Closes #35

## Test plan
- [x] Group tasks by status → change "in progress" to "todo" → verify correct file updates
- [x] Edit a relation column while grouped → verify correct file updates
- [x] Use quick action buttons while grouped → verify correct file updates
- [x] Test edits with no grouping to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)